### PR TITLE
ENH: Update CI for ITK v5.2rc03+

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.1.0"
+            itk-git-tag: "7548a390d71dc25b80e792703ee3cfea17853a99"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.1.0"
+            itk-git-tag: "7548a390d71dc25b80e792703ee3cfea17853a99"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.1.0"
+            itk-git-tag: "7548a390d71dc25b80e792703ee3cfea17853a99"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -38,6 +38,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install ninja
+
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
 
     - name: Download ITK
       run: |
@@ -100,6 +103,9 @@ jobs:
         set(dashboard_no_clean 1)
         set(ENV{CC} ${{ matrix.c-compiler }})
         set(ENV{CXX} ${{ matrix.cxx-compiler }})
+        if(WIN32)
+          set(ENV{PATH} "\${CTEST_DASHBOARD_ROOT}/ITK-build/bin;\$ENV{PATH}")
+        endif()
         set(dashboard_cache "
         ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
         BUILD_TESTING:BOOL=ON
@@ -128,9 +134,9 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [35, 36, 37, 38]
+        python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.1.0.post2"
+          - itk-python-git-tag: "v5.2rc03"
 
     steps:
     - uses: actions/checkout@v2
@@ -166,10 +172,17 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.0.post2"
+          - itk-python-git-tag: "v5.2rc03"
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: 'Specific XCode version'
+      run: |
+        sudo xcode-select -s "/Applications/Xcode_11.7.app"
+
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
 
     - name: 'Fetch build script'
       run: |
@@ -193,11 +206,14 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [5, 6, 7, 8]
+        python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.1.0.post2"
+          - itk-python-git-tag: "v5.2rc03"
 
     steps:
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
     - uses: actions/checkout@v2
       with:
         path: "im"
@@ -233,7 +249,7 @@ jobs:
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v1
       with:
-        name: WindowWheel3.${{ matrix.python-version-minor }}
+        name: WindowsWheel3.${{ matrix.python-version-minor }}
         path: ../../im/dist
 
   publish-python-packages-to-pypi:

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,2 +1,2 @@
 itk-spcn
-itkwidgets==0.30.1
+itkwidgets

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 setup(
     name='itk-spcn',
-    version='0.1.2',
+    version='0.1.3',
     author='Lee Newberg',
     author_email='lee.newberg@kitware.com',
     packages=['itk'],
@@ -47,6 +47,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://github.com/InsightSoftwareConsortium/ITKColorNormalization/',
     install_requires=[
-        r'itk>=5.1.0.post3'
+        r'itk>=5.2rc3'
     ]
     )

--- a/test/azure-pipelines.yml
+++ b/test/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
-  ITKGitTag: v5.1.0
-  ITKPythonGitTag: v5.1.0
+  ITKGitTag: v5.2rc03
+  ITKPythonGitTag: v5.2rc03
   CMakeBuildType: Release
 
 trigger:


### PR DESCRIPTION
ENH: Update CI for ITK v5.2rc03+, including    
* ENH: Allow itkwidgets to be current version instead of 0.30.1 locked
* ENH: Add Python 3.9; Remove Python 3.5
* ENH: Specify CMake version 3.18.3; Xcode version 11.7.
* Build against ITK commit 7548a390d71dc25b80e792703ee3cfea17853a99.
