### PR TITLE
STYLE: Manual formatting

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -136,7 +136,7 @@ jobs:
       matrix:
         python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.2.0"
+          - itk-python-git-tag: "v5.2.1"
 
     steps:
     - uses: actions/checkout@v2
@@ -172,7 +172,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.2.0"
+          - itk-python-git-tag: "v5.2.1"
 
     steps:
     - uses: actions/checkout@v2
@@ -208,7 +208,7 @@ jobs:
       matrix:
         python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.2.0"
+          - itk-python-git-tag: "v5.2.1"
 
     steps:
     - name: Get specific version of CMake, Ninja

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We have set up a demonstration of this using [Binder](www.mybinder.org) that any
 
 [![PyPI Version](https://img.shields.io/pypi/v/itk-spcn.svg)](https://pypi.python.org/pypi/itk-spcn)
 
-ITKColorNormalization and all its dependencies can be easily installed with [Python wheels](https://blog.kitware.com/itk-is-on-pypi-pip-install-itk-is-here/).  Wheels have been generated for macOS, Linux, and Windows and several versions of Python, 3.5, 3.6, 3.7, and 3.8.  If you do not want the installation to be to your current Python environment, you should first create and activate a [Python virtual environment (venv)](https://docs.python.org/3/tutorial/venv.html) to work in.  Then, run the following from the command-line:
+ITKColorNormalization and all its dependencies can be easily installed with [Python wheels](https://blog.kitware.com/itk-is-on-pypi-pip-install-itk-is-here/).  Wheels have been generated for macOS, Linux, and Windows and several versions of Python, 3.6, 3.7, 3.8, and 3.9.  If you do not want the installation to be to your current Python environment, you should first create and activate a [Python virtual environment (venv)](https://docs.python.org/3/tutorial/venv.html) to work in.  Then, run the following from the command-line:
 
 ```shell-script
 pip install itk-spcn
@@ -32,8 +32,9 @@ Launch `python`, import the itk package, and set variable names for the input im
 
 ```python
 import itk
-input_image_filename = 'path/to/image_to_be_normalized'
-reference_image_filename = 'path/to/image_to_be_used_as_color_reference'
+
+input_image_filename = "path/to/image_to_be_normalized"
+reference_image_filename = "path/to/image_to_be_used_as_color_reference"
 ```
 
 ## Usage in Python
@@ -62,7 +63,8 @@ eager_normalized_image = itk.structure_preserving_color_normalization_filter(
     input_image,
     reference_image,
     color_index_suppressed_by_hematoxylin=0,
-    color_index_suppressed_by_eosin=1)
+    color_index_suppressed_by_eosin=1,
+)
 
 itk.imwrite(eager_normalized_image, output_image_filename)
 ```
@@ -75,7 +77,9 @@ Alternatively, you can use the ITK pipeline infrastructure that waits until a ca
 input_reader = itk.ImageFileReader.New(FileName=input_image_filename)
 reference_reader = itk.ImageFileReader.New(FileName=reference_image_filename)
 
-spcn_filter = itk.StructurePreservingColorNormalizationFilter.New(Input=input_reader.GetOutput())
+spcn_filter = itk.StructurePreservingColorNormalizationFilter.New(
+    Input=input_reader.GetOutput()
+)
 spcn_filter.SetColorIndexSuppressedByHematoxylin(0)
 spcn_filter.SetColorIndexSuppressedByEosin(1)
 spcn_filter.SetInput(0, input_reader.GetOutput())

--- a/include/itkStructurePreservingColorNormalizationFilter.h
+++ b/include/itkStructurePreservingColorNormalizationFilter.h
@@ -108,24 +108,25 @@ public:
    * Otherwise, set ColorIndexSuppressedByHematoxylin to the index in
    * the array of colors that indicates the color most suppressed by
    * hematoxylin. */
-  itkGetMacro(ColorIndexSuppressedByHematoxylin, Eigen::Index)
-    itkSetMacro(ColorIndexSuppressedByHematoxylin, Eigen::Index)
+  itkGetMacro(ColorIndexSuppressedByHematoxylin, Eigen::Index);
+  itkSetMacro(ColorIndexSuppressedByHematoxylin, Eigen::Index);
 
-    /** If the pixel type is RGB or RGBA then
-     * ColorIndexSuppressedByEosin defaults to 1, indicating green.
-     * Otherwise, set ColorIndexSuppressedByEosin to the index in the
-     * array of colors that indicates the color most suppressed by
-     * eosin. */
-    itkGetMacro(ColorIndexSuppressedByEosin, Eigen::Index) itkSetMacro(ColorIndexSuppressedByEosin, Eigen::Index)
+  /** If the pixel type is RGB or RGBA then
+   * ColorIndexSuppressedByEosin defaults to 1, indicating green.
+   * Otherwise, set ColorIndexSuppressedByEosin to the index in the
+   * array of colors that indicates the color most suppressed by
+   * eosin. */
+  itkGetMacro(ColorIndexSuppressedByEosin, Eigen::Index);
+  itkSetMacro(ColorIndexSuppressedByEosin, Eigen::Index);
 
-    // This algorithm is defined for H&E (Hematoxylin (blue) and
-    // Eosin (pink)), which is a total of 2 stains.  However, this
-    // approach could in theory work in other circumstances.  In that
-    // case it might be better to have NumberOfStains be a template
-    // parameter or a setable class member.
+  // This algorithm is defined for H&E (Hematoxylin (blue) and
+  // Eosin (pink)), which is a total of 2 stains.  However, this
+  // approach could in theory work in other circumstances.  In that
+  // case it might be better to have NumberOfStains be a template
+  // parameter or a setable class member.
 
-    /** Hematoxylin and eosin; there are two stains supported. */
-    static constexpr SizeValueType NumberOfStains{ 2 };
+  /** Hematoxylin and eosin; there are two stains supported. */
+  static constexpr SizeValueType NumberOfStains{ 2 };
   /** For Virtanen's non-negative matrix factorization algorithm. */
   static constexpr SizeValueType maxNumberOfIterations{ 0 };
   /** Select a subset of the pixels if the image has more than this */
@@ -406,7 +407,7 @@ protected:
 private:
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Add concept checking such as
-  // itkConceptMacro( FloatingPointPixel, ( Concept::IsFloatingPoint< typename ImageType::PixelType > ) );
+  // itkConceptMacro(FloatingPointPixel, (Concept::IsFloatingPoint<typename ImageType::PixelType>));
 #endif
 };
 

--- a/include/itkStructurePreservingColorNormalizationFilter.hxx
+++ b/include/itkStructurePreservingColorNormalizationFilter.hxx
@@ -34,7 +34,7 @@ StructurePreservingColorNormalizationFilter<TImage>::StructurePreservingColorNor
   , m_ColorIndexSuppressedByEosin(Self::PixelHelper<PixelType>::ColorIndexSuppressedByEosin)
 {
   // The number of colors had better be at least 3 or be unknown
-  // ( which is indicated with the value -1 ).
+  // (which is indicated with the value -1).
   static_assert(2 / PixelHelper<PixelType>::NumberOfColors < 1, "Images need at least 3 colors");
 }
 
@@ -67,8 +67,8 @@ StructurePreservingColorNormalizationFilter<TImage>::GenerateInputRequestedRegio
   // Call the superclass' implementation of this method
   Superclass::GenerateInputRequestedRegion();
 
-  // Get pointers to the input image ( to be normalized ) and
-  // reference image.
+  // Get pointers to the input image (to be normalized) and reference
+  // image.
   ImageType * inputImage = const_cast<ImageType *>(this->GetInput(0));
   ImageType * referenceImage = const_cast<ImageType *>(this->GetInput(1));
 
@@ -143,7 +143,7 @@ StructurePreservingColorNormalizationFilter<TImage>::BeforeThreadedGenerateData(
       RegionConstIterator refIt{ m_Reference, m_Reference->GetRequestedRegion() };
       refIt.GoToBegin();
       itkAssertOrThrowMacro(m_NumberOfColors == refIt.Get().Size(),
-                            "The ( cached ) reference image needs its number of colors to be exactly the same as the "
+                            "The (cached) reference image needs its number of colors to be exactly the same as the "
                             "input image to be normalized");
     }
   }
@@ -155,7 +155,7 @@ StructurePreservingColorNormalizationFilter<TImage>::BeforeThreadedGenerateData(
     // we failed
     itkAssertOrThrowMacro(
       m_Input != nullptr,
-      "The image to be normalized could not be processed; does it have white, blue, and pink pixels?")
+      "The image to be normalized could not be processed; does it have white, blue, and pink pixels?");
   }
   m_Input = inputImage;
 
@@ -178,7 +178,7 @@ StructurePreservingColorNormalizationFilter<TImage>::BeforeThreadedGenerateData(
       // we failed
       m_Reference = nullptr;
       itkAssertOrThrowMacro(m_Reference != nullptr,
-                            "The reference image could not be processed; does it have white, blue, and pink pixels?")
+                            "The reference image could not be processed; does it have white, blue, and pink pixels?");
     }
   }
   m_Reference = referenceImage;
@@ -194,7 +194,6 @@ StructurePreservingColorNormalizationFilter<TImage>::BeforeThreadedGenerateData(
     m_ReferenceH.row(0) = referenceHOriginal.row(1);
     m_ReferenceH.row(1) = referenceHOriginal.row(0);
   }
-
   itkAssertOrThrowMacro((m_InputH * m_ReferenceH.transpose()).determinant() > CalcElementType(0),
                         "Hematoxylin and Eosin are getting mixed up; failed");
 }
@@ -205,8 +204,8 @@ void
 StructurePreservingColorNormalizationFilter<TImage>::DynamicThreadedGenerateData(const RegionType & outputRegion)
 {
   ImageType * const outputImage = this->GetOutput();
-  itkAssertOrThrowMacro(outputImage != nullptr, "An output image needs to be supplied")
-    RegionIterator outIt{ outputImage, outputRegion };
+  itkAssertOrThrowMacro(outputImage != nullptr, "An output image needs to be supplied");
+  RegionIterator outIt{ outputImage, outputRegion };
 
   this->NMFsToImage(m_InputH, m_InputUnstainedPixel, m_ReferenceH, m_ReferenceUnstainedPixel, outIt);
 }
@@ -254,7 +253,7 @@ StructurePreservingColorNormalizationFilter<TImage>::ImageToNMF(RegionConstItera
   }
 
   // Rescale each row of matrixH so that the
-  // ( 100-VeryDarkPercentileLevel ) value of each column of matrixW is
+  // (100-VeryDarkPercentileLevel) value of each column of matrixW is
   // 1.0.
   // { std::ostringstream mesg; mesg << "matrixH before NormalizeMatrixH = " << std::endl << matrixH << std::endl;
   // std::cout << mesg.str() << std::flush; }
@@ -370,8 +369,8 @@ StructurePreservingColorNormalizationFilter<TImage>::MatrixToDistinguishers(cons
 {
   const CalcMatrixType normVStart{ matrixV };
 
-  // We will store the row ( pixel ) index of each distinguishing
-  // pixel in firstPassDistinguisherIndices.
+  // We will store the row (pixel) index of each distinguishing pixel
+  // in firstPassDistinguisherIndices.
   std::array<int, NumberOfStains + 1> firstPassDistinguisherIndices{ -1 };
   SizeValueType                       numberOfDistinguishers{ 0 };
   Self::FirstPassDistinguishers(normVStart, firstPassDistinguisherIndices, numberOfDistinguishers);
@@ -399,7 +398,7 @@ StructurePreservingColorNormalizationFilter<TImage>::FirstPassDistinguishers(
   bool needToRecenterMatrix = true;
   while (numberOfDistinguishers <= NumberOfStains)
   {
-    // Find the next distinguishing row ( pixel )
+    // Find the next distinguishing row (pixel)
     firstPassDistinguisherIndices[numberOfDistinguishers] = Self::MatrixToOneDistinguisher(normV);
     // If we found a distinguisher and we have not yet found
     // NumberOfStains+1 of them, then look for the next distinguisher.
@@ -462,8 +461,8 @@ StructurePreservingColorNormalizationFilter<TImage>::SecondPassDistinguishers(
     // We have sent all distinguishers except self to the origin.
     // Whatever is far from the origin in the same direction as self
     // is a good replacement for self.  We will take an average among
-    // those that are at least 80% as far as the best.  ( Note that
-    // self could still be best, but not always. )
+    // those that are at least 80% as far as the best.  (Note that
+    // self could still be best, but not always.)
     const CalcColVectorType dotProducts{ normV * normV.row(firstPassDistinguisherIndices[distinguisher]).transpose() };
     const CalcElementType   threshold{ *std::max_element(Self::cbegin(dotProducts), Self::cend(dotProducts)) *
                                      SecondPassDistinguishersThreshold };
@@ -571,9 +570,9 @@ StructurePreservingColorNormalizationFilter<TImage>::DistinguishersToColors(Calc
                                                                             SizeValueType &        hematoxylinIndex,
                                                                             SizeValueType &        eosinIndex) const
 {
-  // Figure out which, distinguishers are unstained ( highest
-  // brightness ), hematoxylin ( suppresses red ), and eosin (
-  // suppresses green ).
+  // Figure out which, distinguishers are unstained (highest
+  // brightness), hematoxylin (suppresses red), and eosin (suppresses
+  // green).
   const CalcColVectorType       lengths2{ distinguishers.rowwise().squaredNorm() };
   const CalcElementType * const unstainedIterator{ std::max_element(Self::cbegin(lengths2), Self::cend(lengths2)) };
   unstainedIndex = std::distance(Self::cbegin(lengths2), unstainedIterator);
@@ -601,8 +600,8 @@ StructurePreservingColorNormalizationFilter<TImage>::NormalizeMatrixH(const Calc
   const CalcColVectorType firstOnes{ CalcColVectorType::Constant(matrixDarkVIn.rows(), 1, 1.0) };
 
   // Compute the VeryDarkPercentileLevel percentile of a stain's
-  // negative( matrixW ) column.  This a dark value due to its being the
-  // ( 100 - VeryDarkPercentileLevel ) among quantities of stain.
+  // negative(matrixW) column.  This a dark value due to its being the
+  // (100 - VeryDarkPercentileLevel) among quantities of stain.
   CalcRowVectorType logUnstainedCalcPixel = unstainedPixel.unaryExpr(CalcUnaryFunctionPointer(std::log));
   CalcMatrixType    matrixDarkV{ matrixDarkVIn };
   matrixDarkV = (firstOnes * logUnstainedCalcPixel) - matrixDarkV.unaryExpr(CalcUnaryFunctionPointer(std::log));
@@ -836,8 +835,8 @@ StructurePreservingColorNormalizationFilter<TImage>::end(
 {
   itkAssertOrThrowMacro(std::distance(matrix.data(), &matrix(matrix.rows() - 1, matrix.cols() - 1)) + 1 ==
                           matrix.size(),
-                        "Bad array stepping") return matrix.data() +
-    matrix.size();
+                        "Bad array stepping");
+  return matrix.data() + matrix.size();
 }
 
 template <typename TImage>
@@ -848,8 +847,8 @@ StructurePreservingColorNormalizationFilter<TImage>::cend(
 {
   itkAssertOrThrowMacro(std::distance(matrix.data(), &matrix(matrix.rows() - 1, matrix.cols() - 1)) + 1 ==
                           matrix.size(),
-                        "Bad array stepping") return matrix.data() +
-    matrix.size();
+                        "Bad array stepping");
+  return matrix.data() + matrix.size();
 }
 
 #else
@@ -876,8 +875,8 @@ StructurePreservingColorNormalizationFilter<TImage>::end(TMatrix & matrix)
 {
   itkAssertOrThrowMacro(std::distance(matrix.data(), &matrix(matrix.rows() - 1, matrix.cols() - 1)) + 1 ==
                           matrix.size(),
-                        "Bad array stepping") return matrix.data() +
-    matrix.size();
+                        "Bad array stepping");
+  return matrix.data() + matrix.size();
 }
 
 template <typename TImage>
@@ -887,8 +886,8 @@ StructurePreservingColorNormalizationFilter<TImage>::cend(const TMatrix & matrix
 {
   itkAssertOrThrowMacro(std::distance(matrix.data(), &matrix(matrix.rows() - 1, matrix.cols() - 1)) + 1 ==
                           matrix.size(),
-                        "Bad array stepping") return matrix.data() +
-    matrix.size();
+                        "Bad array stepping");
+  return matrix.data() + matrix.size();
 }
 #endif
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 setup(
     name="itk-spcn",
-    version="0.1.5",
+    version="0.1.6",
     author="Lee Newberg",
     author_email="lee.newberg@kitware.com",
     packages=["itk"],
@@ -46,5 +46,5 @@ setup(
     license="Apache",
     keywords="ITK InsightToolkit",
     url=r"https://github.com/InsightSoftwareConsortium/ITKColorNormalization/",
-    install_requires=[r"itk>=5.2.0"],
+    install_requires=[r"itk>=5.2.1.post1"],
 )

--- a/test/azure-pipelines.yml
+++ b/test/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
-  ITKGitTag: v5.2.0
-  ITKPythonGitTag: v5.2.0
+  ITKGitTag: v5.2.1
+  ITKPythonGitTag: v5.2.1
   CMakeBuildType: Release
 
 trigger:

--- a/test/itkStructurePreservingColorNormalizationFilterTest.cxx
+++ b/test/itkStructurePreservingColorNormalizationFilterTest.cxx
@@ -107,8 +107,8 @@ itkStructurePreservingColorNormalizationFilterTest(int argc, char * argv[])
 
   using FilterType = itk::StructurePreservingColorNormalizationFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  // filter->SetColorIndexSuppressedByHematoxylin( 0 );
-  // filter->SetColorIndexSuppressedByEosin( 1 );
+  // filter->SetColorIndexSuppressedByHematoxylin(0);
+  // filter->SetColorIndexSuppressedByEosin(1);
 
   ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, StructurePreservingColorNormalizationFilter, ImageToImageFilter);
 


### PR DESCRIPTION
STYLE: Add trailing semicolons to `itk` macro invocations.
STYLE: Remove extra spaces adjacent to parentheses.
ENH: Bump ITK version to 5.2.1.post1.
ENH: Bump ITKColorNormalization version to 0.1.6.
DOC: Update README.md to indicate supported Python versions 3.6-3.9.
DOC: Update README.md to use `black` Python formatting.