### PR TITLE
BUG: DistinguishersToColors now matches to hematoxylin and eosin

### DIFF
--- a/include/itkStructurePreservingColorNormalizationFilter.h
+++ b/include/itkStructurePreservingColorNormalizationFilter.h
@@ -131,6 +131,9 @@ public:
   static constexpr SizeValueType maxNumberOfIterations{ 0 };
   /** Select a subset of the pixels if the image has more than this */
   static constexpr SizeValueType maxNumberOfRows{ 100000 };
+  /** Useful constants **/
+  static constexpr CalcElementType Zero{ 0.0 };
+  static constexpr CalcElementType One{ 1.0 };
   /** Colors at least this fraction as distance as first pass distinguisher are good substitutes for it. */
   static constexpr CalcElementType SecondPassDistinguishersThreshold{ 0.90 };
   /** Colors that are at least this percentile in brightness are considered bright. */


### PR DESCRIPTION
A bug report indicated an exception thrown for `Hematoxylin and Eosin are getting mixed up; failed` when it should not have.  Further investigation indicated that an earlier exception should have been thrown for `The image to be normalized could not be processed; does it have white, blue, and pink pixels?`.  That was triggered because the same distinguisher was best at suppressing both the color suppressed by hematoxylin and the color suppressed by eosin.  The proper behavior is that the distinguishers assigned to these stains should be distinct.

The fix has a new approach for matching distinguishers with stains.  Specifically, when considering only the 2-dimensional plane that is the colors that are suppressed by hematoxylin and eosin, the angle of each distinguisher suppression vector can be measured in that plane.  The assignment of distinguisher to stain is based upon which distinguisher is closer in angle to that stain's axis. 