### PR TITLE
BUG: Properly characterize size of VariableLengthVector

### DIFF
--- a/include/itkStructurePreservingColorNormalizationFilter.h
+++ b/include/itkStructurePreservingColorNormalizationFilter.h
@@ -164,8 +164,8 @@ protected:
   {
     using PixelType = TPixelType;
     using ValueType = typename PixelType::ValueType;
-    static constexpr SizeValueType         NumberOfDimensions = -1; // unsigned int value!
-    static constexpr SizeValueType         NumberOfColors = -1;     // unsigned int value!
+    static constexpr typename Eigen::Index NumberOfDimensions{ -1 };
+    static constexpr typename Eigen::Index NumberOfColors{ -1 };
     static constexpr typename Eigen::Index ColorIndexSuppressedByHematoxylin{ -1 };
     static constexpr typename Eigen::Index ColorIndexSuppressedByEosin{ -1 };
     static PixelType
@@ -402,10 +402,10 @@ protected:
   CalcMatrixType    m_ReferenceH;
   CalcRowVectorType m_ReferenceUnstainedPixel;
 
-  Eigen::Index m_NumberOfDimensions;
-  Eigen::Index m_NumberOfColors;
-  Eigen::Index m_ColorIndexSuppressedByHematoxylin;
-  Eigen::Index m_ColorIndexSuppressedByEosin;
+  Eigen::Index m_NumberOfDimensions{ Self::PixelHelper<PixelType>::NumberOfDimensions };
+  Eigen::Index m_NumberOfColors{ Self::PixelHelper<PixelType>::NumberOfColors };
+  Eigen::Index m_ColorIndexSuppressedByHematoxylin{ Self::PixelHelper<PixelType>::ColorIndexSuppressedByHematoxylin };
+  Eigen::Index m_ColorIndexSuppressedByEosin{ Self::PixelHelper<PixelType>::ColorIndexSuppressedByEosin };
 
 private:
 #ifdef ITK_USE_CONCEPT_CHECKING

--- a/include/itkStructurePreservingColorNormalizationFilter.hxx
+++ b/include/itkStructurePreservingColorNormalizationFilter.hxx
@@ -28,10 +28,6 @@ namespace itk
 
 template <typename TImage>
 StructurePreservingColorNormalizationFilter<TImage>::StructurePreservingColorNormalizationFilter()
-  : m_NumberOfDimensions(Self::PixelHelper<PixelType>::NumberOfDimensions)
-  , m_NumberOfColors(Self::PixelHelper<PixelType>::NumberOfColors)
-  , m_ColorIndexSuppressedByHematoxylin(Self::PixelHelper<PixelType>::ColorIndexSuppressedByHematoxylin)
-  , m_ColorIndexSuppressedByEosin(Self::PixelHelper<PixelType>::ColorIndexSuppressedByEosin)
 {
   // The number of colors had better be at least 3 or be unknown
   // (which is indicated with the value -1).


### PR DESCRIPTION
The signal of -1 to indicate that the size was variable was stored as an `unsigned int` and thus evaded a check that it was negative.  Now it is stored as a `signed` type, using `{ -1 }` syntax for initialization so that the compiler will warn us if the type alias is later changed to a type that does not support -1.

Also move the constructor's initialization of member variables to the class definition and use `{ }` syntax rather than `=` syntax for those initializations.

Closes Issue #34.