### PR TITLE
ENH: Versions as strings, not numbers, so that 3.1 != 3.10, etc.

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: "3.7"
 
     - name: Install build dependencies
       run: |
@@ -134,7 +134,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [36, 37, 38, 39]
+        python-version: ["36", "37", "38", "39"]
         include:
           - itk-python-git-tag: "v5.2.1"
 
@@ -206,7 +206,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [6, 7, 8, 9]
+        python-version-minor: ["6", "7", "8", "9"]
         include:
           - itk-python-git-tag: "v5.2.1"
 


### PR DESCRIPTION
Re-writes version numbers as strings rather than as numbers in `.github/workflows/*.yml` files because 3.1 != 3.10, etc.  Nothing is broken at present but in the future as, e.g., a Python version goes from 3.8 to 3.9 to 3.10, this could end up being an unexpected problem.